### PR TITLE
use inmanta-dev-dependencies

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,1 @@
-pytest-inmanta
-flake8
-flake8-black
-flake8-isort>3.0.0
-flake8-copyright
-isort
-black
+inmanta-dev-dependencies[module]==2.99.0


### PR DESCRIPTION
# Description

This module still used unconstrained dev dependencies. This led to an alpha release for black being installed, which caused pep8 failures that are difficult to reproduce locally.

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

